### PR TITLE
Mobs Redo Compatibility

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -423,11 +423,11 @@ end
 function mobkit.is_alive(thing)		-- thing can be luaentity or objectref.
 --	if not thing then return false end
 	if not mobkit.exists(thing) then return false end
-	if type(thing) == 'table' then return thing.hp > 0 end
+	if type(thing) == 'table' then return thing.hp > 0 or thing.health > 0 end	-- support for mobs redo
 	if thing:is_player() then return thing:get_hp() > 0
 	else 
 		local lua = thing:get_luaentity()
-		local hp = lua and lua.hp or nil
+		local hp = lua and (lua.hp or lua.health) or nil	-- support for mobs redo
 		return hp and hp > 0
 	end
 end


### PR DESCRIPTION
from the original pr

> Simple edit to the `mobkit.is_alive` function to check for the `health` field (which mobs made using Mobs Redo use)

unsure on the implications if it should actually check since the function is in the mobkit namespace