### PR TITLE
Add warning to API about memory functions + Fix height based errors

### DIFF
--- a/example_behaviors.lua
+++ b/example_behaviors.lua
@@ -585,9 +585,9 @@ function mobkit.hq_attack(self,prty,tgtobj)
 				return true
 			else
 				mobkit.lq_turn2pos(self,tpos)
-				local height = tgtobj:is_player() and 0.35 or tgtobj:get_luaentity().height*0.6
-				if tpos.y+height>pos.y then 
-					mobkit.lq_jumpattack(self,tpos.y+height-pos.y,tgtobj) 
+				local midpoint = mobkit.get_box_height(tgtobj) * 0.5
+				if tpos.y+midpoint>pos.y then 
+					mobkit.lq_jumpattack(self,tpos.y+midpoint-pos.y,tgtobj) 
 				else
 					mobkit.lq_dumbwalk(self,mobkit.pos_shift(tpos,{x=random()-0.5,z=random()-0.5}))
 				end

--- a/init.lua
+++ b/init.lua
@@ -411,13 +411,16 @@ function mobkit.get_box_displace_cols(pos,box,vec,dist)
 end
 
 function mobkit.get_box_height(thing)
-	if type(thing) == 'table' then thing = thing.object end
+	if not thing then return nil end
+	if type(thing) == 'table' then
+		return thing.height or mobkit.get_box_height(thing.object)
+	end
 	local colbox = thing:get_properties().collisionbox
 	local height
-	if colbox then height = colbox[5]-colbox[2] 
+	if colbox then height = colbox[5] - colbox[2]
 	else height = 0.1 end
 	
-	return height > 0 and height or 0.1
+	return height or 0.1
 end
 
 function mobkit.is_alive(thing)		-- thing can be luaentity or objectref.

--- a/mobkit_api.txt
+++ b/mobkit_api.txt
@@ -394,6 +394,7 @@ function mobkit.drive_to_pos(self,tpos,speed,turn_rate,dist)
 This represents mob long term memory
 Warning: Stuff in memory is serialized, never try to remember objectrefs or tables referencing them
 or the engine will crash.
+!!! MEMORY IS REMEMBERED WHEN OBJECTS ARE UNLOADED, IF THE SERVER CRASHES THEN MEMORY WILL BE FORGOTTEN !!!
 
 function mobkit.remember(self,key,val)
 	-- premanently store a key, value pair


### PR DESCRIPTION
**Add warning to API about memory functions:**
(https://github.com/mt-mods/mobkit/issues/6) Memory functions rely on staticdata, which means memory only saves when the object is unloaded. If the server crashes, then memory will be forgotten.

****
**Fix height based errors:**
`mobkit.hq_attack` used `tgtobj:get_luaentity().height`, however only mobkit mobs store their height in their properties. I made it instead depend on the already defined `mobkit.get_box_height`