### PR TITLE
use absolute values of velocity components

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -677,9 +677,9 @@ function mobkit.physics(self)
 		-- dumb friction
 		
 	if self.isonground and not self.isinliquid then
-		vnew = {x= vel.x> 0.2 and vel.x*mobkit.friction or 0,
-				y=vel.y,
-				z=vel.z > 0.2 and vel.z*mobkit.friction or 0}
+		vnew = vector.new(abs(vel.x) > 0.2 and vel.x*mobkit.friction or 0,
+				vel.y,
+				abs(vel.z) > 0.2 and vel.z*mobkit.friction or 0)
 	end
 	
 	-- bounciness


### PR DESCRIPTION
Without math.abs(), this caused any velocity in the negative cardinal directions to be reset to zero due to broken friction math.